### PR TITLE
Bugfix 173

### DIFF
--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -187,7 +187,8 @@ class StorageListener implements EventSubscriberInterface
             return;
         }
 
-        $contentType = $this->boltConfig->get('contenttypes/' . $event->getSubject()->getContentType());
+        $subject = $event->getSubject();
+        $contentType = $this->boltConfig->get('contenttypes/' . $subject->getContentType());
 
         if ($contentType === null) {
             return;
@@ -215,7 +216,7 @@ class StorageListener implements EventSubscriberInterface
         if ($values['id']) {
             /** @var Content $defaultContent */
             $defaultContent = $this->query->getContent(
-                $event->getSubject()->getContentType(),
+                $subject->getContentType(),
                 ['id' => $values['id'], 'returnsingle' => true]
             );
         }

--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -187,7 +187,7 @@ class StorageListener implements EventSubscriberInterface
             return;
         }
 
-        $contentType = $this->boltConfig->get('contenttypes/' . $event->getContentType());
+        $contentType = $this->boltConfig->get('contenttypes/' . $event->getSubject()->getContentType());
 
         if ($contentType === null) {
             return;
@@ -215,7 +215,7 @@ class StorageListener implements EventSubscriberInterface
         if ($values['id']) {
             /** @var Content $defaultContent */
             $defaultContent = $this->query->getContent(
-                $event->getContentType(),
+                $event->getSubject()->getContentType(),
                 ['id' => $values['id'], 'returnsingle' => true]
             );
         }


### PR DESCRIPTION
Fixed a bug where the translation data was not saved if the slug did not match the generated slug

Fixed the bug described here: BoltTranslate#173

The event did not contain the correct contenttype slug, which resulted in empty language data/slug fields.

Fixes: BoltTranslate#173