### PR TITLE
Fixed a bug where the translation data was not saved if the slug did not match the generated slug

### DIFF
--- a/src/EventListener/StorageListener.php
+++ b/src/EventListener/StorageListener.php
@@ -186,7 +186,8 @@ class StorageListener implements EventSubscriberInterface
             return;
         }
 
-        $contentType = $this->boltConfig->get('contenttypes/' . $event->getContentType());
+        $subject = $event->getSubject();
+        $contentType = $this->boltConfig->get('contenttypes/' . $subject->getContentType());
 
         if ($contentType === null) {
             return;
@@ -214,7 +215,7 @@ class StorageListener implements EventSubscriberInterface
         if ($values['id']) {
             /** @var Content $defaultContent */
             $defaultContent = $this->query->getContent(
-                $event->getContentType(),
+                $subject->getContentType(),
                 ['id' => $values['id'], 'returnsingle' => true]
             );
         }


### PR DESCRIPTION
The event did not contain the correct contenttype slug, which resulted in empty language data/slug fields.
